### PR TITLE
Fixes for 4.14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,82 +15,102 @@ environment:
   matrix:    
     - platform: x86
       QTC_VER: 4.5
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x64
       QTC_VER: 4.5
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x86
       QTC_VER: 4.6
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x64
       QTC_VER: 4.6
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x86
       QTC_VER: 4.7
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x64
       QTC_VER: 4.7
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x86
       QTC_VER: 4.8
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x64
       QTC_VER: 4.8
+      QTC_PATCH: 0
       VS_VER: 2015
     
     - platform: x86
       QTC_VER: 4.9
+      QTC_PATCH: 0
       VS_VER: 2017
     
     - platform: x64
       QTC_VER: 4.9
+      QTC_PATCH: 0
       VS_VER: 2017
     
     - platform: x86
       QTC_VER: 4.10
+      QTC_PATCH: 0
       VS_VER: 2017
     
     - platform: x64
       QTC_VER: 4.10
+      QTC_PATCH: 0
       VS_VER: 2017
 
     - platform: x86
       QTC_VER: 4.11
+      QTC_PATCH: 0
       VS_VER: 2017
 
     - platform: x64
       QTC_VER: 4.11
+      QTC_PATCH: 0
       VS_VER: 2017
       
     - platform: x86
       QTC_VER: 4.12
+      QTC_PATCH: 0
       VS_VER: 2017
       
     - platform: x64
       QTC_VER: 4.12
+      QTC_PATCH: 0
       VS_VER: 2017
     
     - platform: x64
       QTC_VER: 4.13
+      QTC_PATCH: 0
       VS_VER: 2020
 
     - platform: x86
       QTC_VER: 4.13
+      QTC_PATCH: 0
       VS_VER: 2020
 
     - platform: x64
       QTC_VER: 4.14
+      QTC_PATCH: 0
       VS_VER: 2020
 
     - platform: x86
       QTC_VER: 4.14
+      QTC_PATCH: 0
       VS_VER: 2020
 
 configuration:
@@ -104,9 +124,9 @@ install:
   - cmd: IF %VS_VER% == 2020 IF %PLATFORM% == x64 SET download_dir=windows_x64  
   - cmd: IF %VS_VER% == 2020 IF %PLATFORM% == x86 SET download_dir=windows_x86
   - cmd: echo %download_dir%
-  - cmd: curl -fsSL "http://download.qt.io/official_releases/qtcreator/%QTC_VER%/%QTC_VER%.0/installer_source/%download_dir%/qtcreator_dev.7z" -o %APPVEYOR_BUILD_FOLDER%\qt-dev.7z
+  - cmd: curl -fsSL "http://download.qt.io/official_releases/qtcreator/%QTC_VER%/%QTC_VER%.%QTC_PATCH%/installer_source/%download_dir%/qtcreator_dev.7z" -o %APPVEYOR_BUILD_FOLDER%\qt-dev.7z
   - cmd: 7z x -y qt-dev.7z -o"%APPVEYOR_BUILD_FOLDER%\qt-src\" | findstr /b /r /c:"\<Everything is Ok"
-  - cmd: curl -fsSL "http://download.qt.io/official_releases/qtcreator/%QTC_VER%/%QTC_VER%.0/installer_source/%download_dir%/qtcreator.7z" -o %APPVEYOR_BUILD_FOLDER%\qt-bin.7z
+  - cmd: curl -fsSL "http://download.qt.io/official_releases/qtcreator/%QTC_VER%/%QTC_VER%.%QTC_PATCH%/installer_source/%download_dir%/qtcreator.7z" -o %APPVEYOR_BUILD_FOLDER%\qt-bin.7z
   - cmd: 7z x -y qt-bin.7z -o"%APPVEYOR_BUILD_FOLDER%\qt-bin\" | findstr /b /r /c:"\<Everything is Ok"
 
 # Setup an environment and generate import libs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pro.user
 *.pro.user.*
 
+.7z
 .moc
 .obj
 .rcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,83 +6,83 @@ matrix:
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.5 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.5 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.6 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.6 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.7 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.7 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.8 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.8 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.9 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.9 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.10 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.10 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.11 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.11 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.12 QTC_DL=linux_gcc_64_rhel72
+          env: QTC_VER=4.12 QTC_PATCH=0 QTC_DL=linux_gcc_64_rhel72
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.13 QTC_DL=linux_x64
+          env: QTC_VER=4.13 QTC_PATCH=0 QTC_DL=linux_x64
         - os: linux
           compiler: gcc
           sudo: required
           dist: trusty
-          env: QTC_VER=4.14 QTC_DL=linux_x64
+          env: QTC_VER=4.14 QTC_PATCH=1 QTC_DL=linux_x64
           
         - os: osx
           compiler: clang
-          env: QTC_VER=4.5 QTC_DL=mac_x64
+          env: QTC_VER=4.5 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.6 QTC_DL=mac_x64
+          env: QTC_VER=4.6 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.7 QTC_DL=mac_x64
+          env: QTC_VER=4.7 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.8 QTC_DL=mac_x64
+          env: QTC_VER=4.8 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.9 QTC_DL=mac_x64
+          env: QTC_VER=4.9 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.10 QTC_DL=mac_x64
+          env: QTC_VER=4.10 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.11 QTC_DL=mac_x64
+          env: QTC_VER=4.11 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.12 QTC_DL=mac_x64
+          env: QTC_VER=4.12 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.13 QTC_DL=mac_x64
+          env: QTC_VER=4.13 QTC_PATCH=0 QTC_DL=mac_x64
         - os: osx
           compiler: clang
-          env: QTC_VER=4.14 QTC_DL=mac_x64
+          env: QTC_VER=4.14 QTC_PATCH=1 QTC_DL=mac_x64
 install:
     - scripts/install.sh
 before_script:

--- a/qtc-sourcetrail.pro
+++ b/qtc-sourcetrail.pro
@@ -5,6 +5,8 @@ CONFIG += c++11
 QMAKE_CXXFLAGS += -std=c++11
 
 DEFINES += SOURCETRAIL_LIBRARY
+DEFINES += VERSION_MINOR=$$QTC_VER_MINOR
+DEFINES += VERSION_MAJOR=$$QTC_VER_MAJOR
 
 # QtCreatorSourcetrail files
 TARGET = Sourcetrail
@@ -63,7 +65,14 @@ QTC_PLUGIN_RECOMMENDS += \
 
 ###### End _dependencies.pri contents ######
 
-include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
+#Check version cause after 4.13 structure slightly changed
+greaterThan(QTC_VER_MINOR, 13) | greaterThan(QTC_VER_MAJOR, 4){
+    include($$IDE_SOURCE_TREE/include/src/qtcreatorplugin.pri)
+}
+
+lessThan(QTC_VER_MINOR, 13) | lessThan(QTC_VER_MAJOR, 4){
+    include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
+}
 
 FORMS += \
     src/sourcetrailpluginsettingspage.ui

--- a/scripts/before_script.sh
+++ b/scripts/before_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-QT_LINK_PREFIX="http://download.qt.io/official_releases/qtcreator/$QTC_VER/$QTC_VER.0/installer_source"
+QT_LINK_PREFIX="http://download.qt.io/official_releases/qtcreator/$QTC_VER/$QTC_VER.$QTC_PATCH/installer_source"
 QT_SRC_FILE="qtcreator_dev.7z"
 QT_BIN_FILE="qtcreator.7z"
 
@@ -12,3 +12,15 @@ curl -fsSL "$QT_LINK_PREFIX/$QTC_DL/$QT_BIN_FILE" -o qt-bin.7z
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   cd qt-bin && ln -s ./ bin
 fi
+
+IFS='.' read -ra QTC_VERS <<< "$QTC_VER"
+
+#Create symlinks without version for qt version >=4.14
+if [[ ${QTC_VERS[0]} -gt 3  ]] && [[ ${QTC_VERS[1]} -gt 13  ]]; then
+	cd "qt-bin/lib/qtcreator"
+	for file in *.so.4; do
+		symlink=$(echo "$file" | sed 's/\([^/].so\).4*/\1/')
+		ln -s "$file" "$symlink" || true
+	done
+fi
+

--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+IFS='.' read -ra QTC_VERS <<< "$QTC_VER"
+
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    qmake qtc-sourcetrail.pro -r "QTC_SOURCE=$TRAVIS_BUILD_DIR/qt-src" "QTC_BUILD=$TRAVIS_BUILD_DIR/qt-bin" "LIBS+=-L$TRAVIS_BUILD_DIR/qt-bin" "OUTPUT_PATH=$TRAVIS_BUILD_DIR/output"
+    qmake qtc-sourcetrail.pro -r "QTC_VER_MAJOR=${QTC_VERS[0]}" "QTC_VER_MINOR=${QTC_VERS[1]}" "QTC_SOURCE=$TRAVIS_BUILD_DIR/qt-src" "QTC_BUILD=$TRAVIS_BUILD_DIR/qt-bin" "LIBS+=-L$TRAVIS_BUILD_DIR/qt-bin" "OUTPUT_PATH=$TRAVIS_BUILD_DIR/output"
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    qmake qtc-sourcetrail.pro -r "QTC_SOURCE=$TRAVIS_BUILD_DIR/qt-src" "QTC_BUILD=$TRAVIS_BUILD_DIR/qt-bin/lib/qtcreator" "LIBS+=-L$TRAVIS_BUILD_DIR/qt-bin/lib/qtcreator" "OUTPUT_PATH=$TRAVIS_BUILD_DIR/output"
+    qmake qtc-sourcetrail.pro -r "QTC_VER_MAJOR=${QTC_VERS[0]}" "QTC_VER_MINOR=${QTC_VERS[1]}" "QTC_SOURCE=$TRAVIS_BUILD_DIR/qt-src" "QTC_BUILD=$TRAVIS_BUILD_DIR/qt-bin/lib/qtcreator" "LIBS+=-L$TRAVIS_BUILD_DIR/qt-bin/lib/qtcreator" "OUTPUT_PATH=$TRAVIS_BUILD_DIR/output"
 fi
 
 make

--- a/src/sourcetrailpluginsettingspage.cpp
+++ b/src/sourcetrailpluginsettingspage.cpp
@@ -14,7 +14,12 @@ SourcetrailPluginSettingsPage::SourcetrailPluginSettingsPage(QObject *parent) :
     setId(Constants::CATEGORY_ID);
     setDisplayName(tr(Constants::CATEGORY));
 
+#if (VERSION_MAJOR>3 && VERSION_MINOR>13)
+    setCategory(Utils::Id(Constants::CATEGORY_ID));
+#else
     setCategory(Core::Id(Constants::CATEGORY_ID));
+#endif
+
     setDisplayCategory(QLatin1String(Constants::CATEGORY));
     setCategoryIcon(Utils::Icon(Constants::CATEGORY_ICON));
 


### PR DESCRIPTION
I am unable to push to your fork, so I forked your repo and made some changes to be able to build 4.14. Hope this will help.

Commit comment:
Add .7z to ignore
Add QT patch version to environment variable to be able to build not only 0 patch. Cause for some reason 4.14.0 doesnt have any .pri
Update code to meet version 4.14
Fix problems due to changes in path structure in qtcreator-dev. In 4.14 src moved to include/src